### PR TITLE
Fix the InvocationTargetException when running tests with Gradle

### DIFF
--- a/src/test/java/com/nulabinc/zxcvbn/MatchingTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/MatchingTest.java
@@ -2,7 +2,6 @@ package com.nulabinc.zxcvbn;
 
 import com.nulabinc.zxcvbn.matchers.*;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -460,8 +459,7 @@ public class MatchingTest {
         }
     }
 
-    @Ignore
-    public static class ExpectedMatch {
+    private static class ExpectedMatch {
         String token;
         int start;
         int end;


### PR DESCRIPTION
Static inner class ExpectedMatch was annotated with @org.junit.Ignore.
This broke assumptions of the JUnit4Runner expecting to find a test class
when Gradle tries to enumerate ignored tests. Making it `private` instead of ignoring
solves the problem.

For example, here's the exception in the latest (passing) build: [build 95](https://travis-ci.org/nulab/zxcvbn4j/builds/215534921#L281).