### PR TITLE
 Improve extensibility of Zxcvbn and Matching and optimize memory usage

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/Matching.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Matching.java
@@ -1,9 +1,14 @@
 package com.nulabinc.zxcvbn;
 
-import com.nulabinc.zxcvbn.matchers.*;
 import com.nulabinc.zxcvbn.matchers.Dictionary;
+import com.nulabinc.zxcvbn.matchers.Match;
+import com.nulabinc.zxcvbn.matchers.OmnibusMatcher;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class Matching {
 
@@ -12,32 +17,32 @@ public class Matching {
         for (Map.Entry<String, String[]> frequencyListRef : Dictionary.FREQUENCY_LISTS.entrySet()) {
             String name = frequencyListRef.getKey();
             String[] ls = frequencyListRef.getValue();
-            BASE_RANKED_DICTIONARIES.put(name, buildRankedDict(ls));
+            BASE_RANKED_DICTIONARIES.put(name, buildRankedDict(Arrays.asList(ls)));
         }
     }
 
     private final Map<String, Map<String, Integer>> rankedDictionaries;
 
     public Matching() {
-        this(new ArrayList<String>());
+        this(null);
     }
 
     public Matching(List<String> orderedList) {
-        if (orderedList == null) orderedList = new ArrayList<>();
-        this.rankedDictionaries = new HashMap<>();
-        for (Map.Entry<String, Map<String, Integer>> baseRankedDictionary : BASE_RANKED_DICTIONARIES.entrySet()) {
-            this.rankedDictionaries.put(
-                    baseRankedDictionary.getKey(),
-                    baseRankedDictionary.getValue());
+        this.rankedDictionaries = new HashMap<>(BASE_RANKED_DICTIONARIES);
+        Map<String, Integer> rankedUserInputs;
+        if (orderedList != null && !orderedList.isEmpty()) {
+            rankedUserInputs = buildRankedDict(orderedList);
+        } else {
+            rankedUserInputs = Collections.emptyMap();
         }
-        this.rankedDictionaries.put("user_inputs", buildRankedDict(orderedList.toArray(new String[]{})));
+        this.rankedDictionaries.put("user_inputs", rankedUserInputs);
     }
 
     public List<Match> omnimatch(String password) {
         return new OmnibusMatcher(rankedDictionaries).execute(password);
     }
 
-    private static Map<String, Integer> buildRankedDict(String[] orderedList) {
+    private static Map<String, Integer> buildRankedDict(List<String> orderedList) {
         HashMap<String, Integer> result = new HashMap<>();
         int i = 1; // rank starts at 1, not 0
         for(String word: orderedList) {

--- a/src/main/java/com/nulabinc/zxcvbn/Matching.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Matching.java
@@ -21,14 +21,22 @@ public class Matching {
         }
     }
 
-    private final Map<String, Map<String, Integer>> rankedDictionaries;
+    protected final Map<String, Map<String, Integer>> rankedDictionaries;
 
     public Matching() {
         this(null);
     }
 
     public Matching(List<String> orderedList) {
-        this.rankedDictionaries = new HashMap<>(BASE_RANKED_DICTIONARIES);
+        this(BASE_RANKED_DICTIONARIES, orderedList);
+    }
+
+    protected Matching(Map<String, Map<String, Integer>> rankedDictionaries, List<String> orderedList) {
+        if (rankedDictionaries != null) {
+            this.rankedDictionaries = new HashMap<>(rankedDictionaries);
+        } else {
+            this.rankedDictionaries = new HashMap<>();
+        }
         Map<String, Integer> rankedUserInputs;
         if (orderedList != null && !orderedList.isEmpty()) {
             rankedUserInputs = buildRankedDict(orderedList);
@@ -42,7 +50,7 @@ public class Matching {
         return new OmnibusMatcher(rankedDictionaries).execute(password);
     }
 
-    private static Map<String, Integer> buildRankedDict(List<String> orderedList) {
+    protected static Map<String, Integer> buildRankedDict(List<String> orderedList) {
         HashMap<String, Integer> result = new HashMap<>();
         int i = 1; // rank starts at 1, not 0
         for(String word: orderedList) {

--- a/src/main/java/com/nulabinc/zxcvbn/Zxcvbn.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Zxcvbn.java
@@ -3,6 +3,7 @@ package com.nulabinc.zxcvbn;
 import com.nulabinc.zxcvbn.matchers.Match;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Zxcvbn {
@@ -18,11 +19,14 @@ public class Zxcvbn {
         if (password == null) {
             throw new IllegalArgumentException("Password is null.");
         }
-        List<String> lowerSanitizedInputs = new ArrayList<>();
-        if (sanitizedInputs != null) {
+        List<String> lowerSanitizedInputs;
+        if (sanitizedInputs != null && !sanitizedInputs.isEmpty()) {
+            lowerSanitizedInputs = new ArrayList<>(sanitizedInputs.size());
             for (String sanitizedInput : sanitizedInputs) {
                 lowerSanitizedInputs.add(sanitizedInput.toLowerCase());
             }
+        } else {
+            lowerSanitizedInputs = Collections.emptyList();
         }
         long start = time();
         Matching matching = new Matching(lowerSanitizedInputs);

--- a/src/main/java/com/nulabinc/zxcvbn/Zxcvbn.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Zxcvbn.java
@@ -29,7 +29,7 @@ public class Zxcvbn {
             lowerSanitizedInputs = Collections.emptyList();
         }
         long start = time();
-        Matching matching = new Matching(lowerSanitizedInputs);
+        Matching matching = createMatching(lowerSanitizedInputs);
         List<Match> matches = matching.omnimatch(password);
         Strength strength = Scoring.mostGuessableMatchSequence(password, matches);
         strength.setCalcTime(time() - start);
@@ -39,6 +39,10 @@ public class Zxcvbn {
         strength.setScore(attackTimes.getScore());
         strength.setFeedback(Feedback.getFeedback(strength.getScore(), strength.getSequence()));
         return strength;
+    }
+
+    protected Matching createMatching(List<String> lowerSanitizedInputs) {
+        return new Matching(lowerSanitizedInputs);
     }
 
     private long time() {


### PR DESCRIPTION
Change `Zxcvbn` and `Matching` classes to make extending their behavior possible without changing current public API. The main idea is to allow usage of custom (extended) `Matching` class with `Zxcvbn`.

One of possible uses is implementing support for custom user dictionary that is parsed/processed just once and then reused for subsequent calls to `Zxcvbn#measure(String, List<String>)`. Passing large user dictionary to each call of measure causes noticeable slowdown and generates unnecessary GC overhead.

Also includes optimizations avoiding unnecessary allocations for standard use cases.