### PR TITLE
Use system class loader to access resources

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/matchers/Dictionary.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/Dictionary.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class Dictionary {
 
-    private static final String RESOURCES_PACKAGE_PATH = "/com/nulabinc/zxcvbn/matchers/dictionarys/";
+    private static final String RESOURCES_PACKAGE_PATH = "com/nulabinc/zxcvbn/matchers/dictionarys/";
 
     private static final String EXT = ".txt";
 
@@ -40,8 +41,8 @@ public class Dictionary {
         Map<String, String[]> freqLists = new HashMap<>();
         for (String filename:  DICTIONARY_PARAMS) {
             List<String> words = new ArrayList<>();
-            try(InputStream is = Dictionary.class.getResourceAsStream(buildResourcePath(filename));
-                BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));) {
+            try(InputStream is = ClassLoader.getSystemResourceAsStream(buildResourcePath(filename));
+                BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = br.readLine()) != null) {
                     words.add(line);

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/Keyboard.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/Keyboard.java
@@ -13,20 +13,22 @@ import java.util.Map;
 
 public class Keyboard {
 
+    private static final String RESOURCES_PACKAGE_PATH = "com/nulabinc/zxcvbn/matchers/keyboards/";
+
     public static final Keyboard QWERTY =
-            new Keyboard("qwerty", new SlantedAdjacentGraphBuilder(loadAsString("keyboards/qwerty.txt")));
+            new Keyboard("qwerty", new SlantedAdjacentGraphBuilder(loadAsString("qwerty.txt")));
 
     public static final Keyboard DVORAK =
-            new Keyboard("dvorak", new SlantedAdjacentGraphBuilder(loadAsString("keyboards/dvorak.txt")));
+            new Keyboard("dvorak", new SlantedAdjacentGraphBuilder(loadAsString("dvorak.txt")));
 
     public static final Keyboard JIS =
-            new Keyboard("jis", new SlantedAdjacentGraphBuilder(loadAsString("keyboards/jis.txt")));
+            new Keyboard("jis", new SlantedAdjacentGraphBuilder(loadAsString("jis.txt")));
 
     public static final Keyboard KEYPAD =
-            new Keyboard("keypad", new AlignedAdjacentAdjacentGraphBuilder(loadAsString("keyboards/keypad.txt")));
+            new Keyboard("keypad", new AlignedAdjacentAdjacentGraphBuilder(loadAsString("keypad.txt")));
 
     public static final Keyboard MAC_KEYPAD =
-            new Keyboard("mac_keypad", new AlignedAdjacentAdjacentGraphBuilder(loadAsString("keyboards/mac_keypad.txt")));
+            new Keyboard("mac_keypad", new AlignedAdjacentAdjacentGraphBuilder(loadAsString("mac_keypad.txt")));
 
     public static final List<Keyboard> ALL_KEYBOARDS = Arrays.asList(QWERTY, DVORAK, JIS, KEYPAD, MAC_KEYPAD);
 
@@ -69,8 +71,8 @@ public class Keyboard {
     }
 
     private static String loadAsString(final String name) {
-        try (final InputStream input = Keyboard.class.getResourceAsStream(name);
-             final BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"))) {
+        try (final InputStream input = ClassLoader.getSystemResourceAsStream(RESOURCES_PACKAGE_PATH + name);
+             final BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             final StringBuilder sb = new StringBuilder(1024 * 4);
             String str;
             while ((str = reader.readLine()) != null) {


### PR DESCRIPTION
When this library is obfuscated, loading resources using a relative path might not work anymore (was the case for us). Therefore we had to exclude those classes from being obfuscated. This change uses absolute paths to load resources, so there is no client-side configuration needed to work with code obfuscation tools.