### PR TITLE
remove openjdk7 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
-  - oraclejdk9
-install:
-  # workaround for the missing EC cipher suites
-  # will download Gradle distribution using OracleJDK8
-  - if [ "openjdk7" == "$TRAVIS_JDK_VERSION" ]; then JAVA_HOME=$(jdk_switcher home openjdk8) ./gradlew testClasses ; fi
+  - openjdk12
 after_success:
   - ./gradlew cobertura coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.0.0' // cobertura plugin
+        classpath 'net.saliman:gradle-cobertura-plugin:2.6.1' // cobertura plugin
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'cobertura'
+apply plugin: 'net.saliman.cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
 
 apply from: 'dictionary.gradle'
@@ -21,8 +21,8 @@ archivesBaseName = 'zxcvbn'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.6'
+wrapper {
+    gradleVersion = '5.5'
 }
 
 repositories {
@@ -142,9 +142,3 @@ test {
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     forkEvery = 4
 }
-
-task preCompile << {
-    tasks.createDictionary.execute()
-}
-
-compileJava.dependsOn preCompile

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip


### PR DESCRIPTION
TravisCI now doesn't support openjdk7.

Oracle JDK 9 is no longer available.
Upgrade to OpenJDK 12 (current GA).