### PR TITLE
add performance benchmarks with jmh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ buildscript {
     }
 }
 
+plugins {
+    id "me.champeau.gradle.jmh" version "0.5.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'net.saliman.cobertura'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/src/jmh/java/com/nulabinc/zxcvbn/RandomPasswordMeasureBenchmark.java
+++ b/src/jmh/java/com/nulabinc/zxcvbn/RandomPasswordMeasureBenchmark.java
@@ -1,0 +1,36 @@
+package com.nulabinc.zxcvbn;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@Fork(1)
+public class RandomPasswordMeasureBenchmark {
+
+  @Param({"8", "32", "128", "512", "1024"})
+  private int passwordLength;
+  private String password;
+  Zxcvbn zxcvbn = new Zxcvbn();
+
+  @Setup
+  public void setup() {
+    Random random = new Random(42);
+    StringBuilder sb = new StringBuilder(passwordLength);
+    for (int i = 0; i < passwordLength; i++) {
+      char c = (char) (random.nextInt() % Character.MAX_VALUE);
+      sb.append(c);
+    }
+    password = sb.toString();
+  }
+
+  @Benchmark
+  public Strength measure() {
+    return zxcvbn.measure(password);
+  }
+}


### PR DESCRIPTION
Hey, @vvatanabe! As @jrivard reported in https://github.com/nulab/zxcvbn4j/issues/67, measuring the strength of long password might be quite slow. To make performance measurable and be able to estimate the effect of potential optimisations, this PR introduces a [JMH](https://hg.openjdk.java.net/code-tools/jmh)-based set of benchmarks. 

Here are the results I got on my laptop:
```
Benchmark                               (passwordLength)  Mode  Cnt     Score      Error  Units
RandomPasswordMeasureBenchmark.measure                 8  avgt   15     0.089 ±    0.053  ms/op
RandomPasswordMeasureBenchmark.measure                32  avgt   15     2.576 ±    1.115  ms/op
RandomPasswordMeasureBenchmark.measure               128  avgt   15    16.859 ±    3.086  ms/op
RandomPasswordMeasureBenchmark.measure               512  avgt   15   853.602 ±  360.256  ms/op
RandomPasswordMeasureBenchmark.measure              1024  avgt   15  8141.381 ± 4908.212  ms/op
```

Results from a c5.large AWS instance: 
```
Benchmark                               (passwordLength)  Mode  Cnt     Score    Error  Units
RandomPasswordMeasureBenchmark.measure                 8  avgt   15     0.032 ±  0.001  ms/op
RandomPasswordMeasureBenchmark.measure                32  avgt   15     0.498 ±  0.008  ms/op
RandomPasswordMeasureBenchmark.measure               128  avgt   15     9.961 ±  0.080  ms/op
RandomPasswordMeasureBenchmark.measure               512  avgt   15   396.688 ±  1.766  ms/op
RandomPasswordMeasureBenchmark.measure              1024  avgt   15  2899.168 ± 25.199  ms/op
```