### PR TITLE
fix inconsistent score between zxcvbn4j and zxcvbn (#50)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,4 +141,5 @@ uploadArchives {
 test {
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     forkEvery = 4
+    testLogging.showStandardStreams = true
 }

--- a/src/main/java/com/nulabinc/zxcvbn/guesses/DateGuess.java
+++ b/src/main/java/com/nulabinc/zxcvbn/guesses/DateGuess.java
@@ -8,7 +8,7 @@ public class DateGuess extends BaseGuess {
     public double exec(Match match) {
         double yearSpace = Math.max(Math.abs(match.year - REFERENCE_YEAR), MIN_YEAR_SPACE);
         double guesses = yearSpace * 365;
-        if (match.separator != null) guesses *= 4;
+        if (match.separator != null && !match.separator.isEmpty()) guesses *= 4;
         return guesses;
     }
 }

--- a/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
@@ -122,9 +122,9 @@ public class FeedbackTest {
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
                         Feedback.SEQUENCE_SUGGESTIONS_AVOID_SEQUENCES
                 }},
-                {new SimpleDateFormat("yyyy").format(new Date()), Feedback.REGEX_WARNING_RECENT_YEARS, new String[]{
+                {new SimpleDateFormat("yyyy").format(new Date()), Feedback.REPEAT_WARNING_LIKE_ABCABCABC, new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
-                        Feedback.REGEX_SUGGESTIONS_AVOID_RECENT_YEARS
+                        Feedback.REPEAT_SUGGESTIONS_AVOID_REPEATED_WORDS
                 }},
                 {new SimpleDateFormat("dd-MM-yyyy").format(new Date()), Feedback.DATE_WARNING_DATES, new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,

--- a/src/test/java/com/nulabinc/zxcvbn/JavaPortTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/JavaPortTest.java
@@ -82,7 +82,11 @@ public class JavaPortTest {
                 {"xsw234rfvb"},
                 {"yaq123edc"},
                 {"cde345tgbn"},
-                {"yaqwedcvb"}
+                {"yaqwedcvb"},
+                {"5621127"},
+                {"61526611441"},
+                {"0078690420729"},
+                {"zhang198822"},
                 //the following password fails in version 4.4.1
                 //https://github.com/dropbox/zxcvbn/issues/174
 //                {"Rh&pW%EXT=/Z1lzouG.wU_+2MT+FG4sm+&jqN?L25jDtjW3EQuppfvD_30Vo3K=SX4=z3-U2gVf7A0oSM5oWegRa_sV$-GLI3LzCo&@!h@$v#OkoN#@-eS8Y&W$pGmmVXc#XHAv?n$M+_wQx1FAB_*iaZE1_9ZV.cwn-d@+90B8z0bVOKc63lV9QntW0kryN7Y#rjv@0+Bd8hc-3WW_Yn%z5/DE?R*UeiKgR#$/F8kA9I!Ib*GDa.x0T7UWCCxDV&ithebyz$=7vW6TdmlmL%WZxmA7K%*Rg1035UO%WOTIgiMs4AjpmL1"}


### PR DESCRIPTION
There was a problem with DateGuess.

It needs a null check and an empty character check for the separator.