### PR TITLE
Fix a ExceptionInInitializerError in Keycloak: error found in ResourceLoader #79

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/matchers/ResourceLoader.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/ResourceLoader.java
@@ -5,10 +5,51 @@ import java.io.InputStream;
 class ResourceLoader {
 
     InputStream getInputStream(String path) {
-        InputStream resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
-        if (resource != null) {
-            return resource;
+        ClassLoader cl = getDefaultClassLoader();
+        if (cl == null) {
+            throw new IllegalStateException("Cannot determine classloader");
         }
-        return ClassLoader.getSystemResourceAsStream(path);
+        return cl.getResourceAsStream(path);
+    }
+
+    /**
+     * This code is a copy of spring-framework's ClassUtils#getDefaultClassLoader().
+     * https://github.com/spring-projects/spring-framework/blob/dfb7ca733ad309b35040e0027fb7a2f10f3a196a/spring-core/src/main/java/org/springframework/util/ClassUtils.java#L173-L210
+     *
+     * Return the default ClassLoader to use: typically the thread context
+     * ClassLoader, if available; the ClassLoader that loaded the ClassUtils
+     * class will be used as fallback.
+     * <p>Call this method if you intend to use the thread context ClassLoader
+     * in a scenario where you clearly prefer a non-null ClassLoader reference:
+     * for example, for class path resource loading (but not necessarily for
+     * {@code Class.forName}, which accepts a {@code null} ClassLoader
+     * reference as well).
+     * @return the default ClassLoader (only {@code null} if even the system
+     * ClassLoader isn't accessible)
+     * @see Thread#getContextClassLoader()
+     * @see ClassLoader#getSystemClassLoader()
+     */
+    public static ClassLoader getDefaultClassLoader() {
+        ClassLoader cl = null;
+        try {
+            cl = Thread.currentThread().getContextClassLoader();
+        }
+        catch (Throwable ex) {
+            // Cannot access thread context ClassLoader - falling back...
+        }
+        if (cl == null) {
+            // No thread context class loader -> use class loader of this class.
+            cl = ResourceLoader.class.getClassLoader();
+            if (cl == null) {
+                // getClassLoader() returning null indicates the bootstrap ClassLoader
+                try {
+                    cl = ClassLoader.getSystemClassLoader();
+                }
+                catch (Throwable ex) {
+                    // Cannot access system ClassLoader - oh well, maybe the caller can live with null...
+                }
+            }
+        }
+        return cl;
     }
 }

--- a/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
@@ -122,9 +122,9 @@ public class FeedbackTest {
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
                         Feedback.SEQUENCE_SUGGESTIONS_AVOID_SEQUENCES
                 }},
-                {new SimpleDateFormat("yyyy").format(new Date()), Feedback.REPEAT_WARNING_LIKE_ABCABCABC, new String[]{
+                {new SimpleDateFormat("yyyy").format(new Date()), Feedback.DATE_WARNING_DATES, new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
-                        Feedback.REPEAT_SUGGESTIONS_AVOID_REPEATED_WORDS
+                        Feedback.DATE_SUGGESTIONS_AVOID_DATES
                 }},
                 {new SimpleDateFormat("dd-MM-yyyy").format(new Date()), Feedback.DATE_WARNING_DATES, new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,


### PR DESCRIPTION
ClassLoader might be null, so I added a fallback method based on the Spring Framework implementation.

> Returns the class loader for the class. Some implementations may use null to represent the bootstrap class loader. This method will return null in such implementations if this class was loaded by the bootstrap class loader

- https://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getClassLoader()
- https://github.com/spring-projects/spring-framework/blob/dfb7ca733ad309b35040e0027fb7a2f10f3a196a/spring-core/src/main/java/org/springframework/util/ClassUtils.java#L173-L210