### PR TITLE
Bump junit 4.11 to 4.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report


### PR DESCRIPTION
Bump the version of dependencies according to the deps.dev security advisory warnings.
https://deps.dev/maven/com.nulab-inc%3Azxcvbn