### PR TITLE
refactor: refactoring matchers.L33tMatcher

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/matchers/BaseMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/BaseMatcher.java
@@ -24,21 +24,6 @@ public abstract class BaseMatcher implements Matcher {
         return matches;
     }
 
-    protected CharSequence translate(CharSequence string, Map<Character, Character> chrMap) {
-        List<Character> characters = new ArrayList<>();
-        for (int n = 0; n < string.length(); n++) {
-            char chr = string.charAt(n);
-            characters.add(chrMap.containsKey(chr) ? chrMap.get(chr) : chr);
-        }
-        StringBuilder sb = new StringBuilder();
-        for (char c: characters) {
-            sb.append(c);
-        }
-        WipeableString result = new WipeableString(sb);
-        WipeableString.wipeIfPossible(sb);
-        return result;
-    }
-
     private static class MatchComparator implements Comparator<Match>, Serializable {
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
@@ -2,7 +2,6 @@ package com.nulabinc.zxcvbn.matchers;
 
 import com.nulabinc.zxcvbn.Context;
 import com.nulabinc.zxcvbn.WipeableString;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,106 +10,108 @@ import java.util.Map;
 
 public class L33tMatcher extends BaseMatcher {
 
-    private final Map<String, Map<String, Integer>> rankedDictionaries;
+  private final Map<String, Map<String, Integer>> rankedDictionaries;
 
-    public L33tMatcher(Context context, Map<String, Map<String, Integer>> rankedDictionaries) {
-        super(context);
-        this.rankedDictionaries = rankedDictionaries;
+  public L33tMatcher(Context context, Map<String, Map<String, Integer>> rankedDictionaries) {
+    super(context);
+    this.rankedDictionaries = rankedDictionaries;
+  }
+
+  private static final Map<Character, List<Character>> L33T_TABLE;
+
+  static {
+    Map<Character, List<Character>> l33tTable = new HashMap<>();
+    l33tTable.put('a', Arrays.asList('4', '@'));
+    l33tTable.put('b', Arrays.asList('8'));
+    l33tTable.put('c', Arrays.asList('(', '{', '[', '<'));
+    l33tTable.put('e', Arrays.asList('3'));
+    l33tTable.put('g', Arrays.asList('6', '9'));
+    l33tTable.put('i', Arrays.asList('1', '!', '|'));
+    l33tTable.put('l', Arrays.asList('1', '|', '7'));
+    l33tTable.put('o', Arrays.asList('0'));
+    l33tTable.put('s', Arrays.asList('$', '5'));
+    l33tTable.put('t', Arrays.asList('+', '7'));
+    l33tTable.put('x', Arrays.asList('%'));
+    l33tTable.put('z', Arrays.asList('2'));
+    L33T_TABLE = l33tTable;
+  }
+
+  public Map<Character, List<Character>> relevantL33tSubTable(CharSequence password) {
+    return relevantL33tSubTable(password, L33T_TABLE);
+  }
+
+  public Map<Character, List<Character>> relevantL33tSubTable(
+      CharSequence password, Map<Character, List<Character>> table) {
+    HashMap<Character, Boolean> passwordChars = new HashMap<>();
+    for (int n = 0; n < password.length(); n++) {
+      passwordChars.put(password.charAt(n), true);
     }
-
-    private static final Map<Character, List<Character>> L33T_TABLE;
-
-    static {
-        Map<Character, List<Character>> l33tTable = new HashMap<>();
-        l33tTable.put('a', Arrays.asList('4', '@'));
-        l33tTable.put('b', Arrays.asList('8'));
-        l33tTable.put('c', Arrays.asList('(', '{', '[', '<'));
-        l33tTable.put('e', Arrays.asList('3'));
-        l33tTable.put('g', Arrays.asList('6', '9'));
-        l33tTable.put('i', Arrays.asList('1', '!', '|'));
-        l33tTable.put('l', Arrays.asList('1', '|', '7'));
-        l33tTable.put('o', Arrays.asList('0'));
-        l33tTable.put('s', Arrays.asList('$', '5'));
-        l33tTable.put('t', Arrays.asList('+', '7'));
-        l33tTable.put('x', Arrays.asList('%'));
-        l33tTable.put('z', Arrays.asList('2'));
-        L33T_TABLE = l33tTable;
-    }
-
-    public Map<Character, List<Character>> relevantL33tSubTable(CharSequence password) {
-        return relevantL33tSubTable(password, L33T_TABLE);
-    }
-
-    public Map<Character, List<Character>> relevantL33tSubTable(CharSequence password, Map<Character, List<Character>> table) {
-        HashMap<Character, Boolean> passwordChars = new HashMap<>();
-        for (int n = 0; n < password.length(); n++) {
-            passwordChars.put(password.charAt(n), true);
+    Map<Character, List<Character>> subTable = new HashMap<>();
+    for (Map.Entry<Character, List<Character>> l33tRowRef : table.entrySet()) {
+      Character letter = l33tRowRef.getKey();
+      List<Character> subs = l33tRowRef.getValue();
+      List<Character> relevantSubs = new ArrayList<>();
+      for (Character sub : subs) {
+        if (passwordChars.containsKey(sub)) {
+          relevantSubs.add(sub);
         }
-        Map<Character, List<Character>> subTable = new HashMap<>();
-        for (Map.Entry<Character, List<Character>> l33tRowRef : table.entrySet()) {
-            Character letter = l33tRowRef.getKey();
-            List<Character> subs = l33tRowRef.getValue();
-            List<Character> relevantSubs = new ArrayList<>();
-            for (Character sub : subs) {
-                if (passwordChars.containsKey(sub)) {
-                    relevantSubs.add(sub);
-                }
-            }
-            if (relevantSubs.size() > 0) {
-                subTable.put(letter, relevantSubs);
-            }
-        }
-        return subTable;
+      }
+      if (relevantSubs.size() > 0) {
+        subTable.put(letter, relevantSubs);
+      }
     }
+    return subTable;
+  }
 
-    @Override
-    public List<Match> execute(CharSequence password) {
-        List<Match> matches = new ArrayList<>();
-        Map<Character, List<Character>> subTable = relevantL33tSubTable(password);
-        L33tSubDict l33tSubs = new L33tSubDict(subTable);
-        for (Map<Character, Character> sub : l33tSubs) {
-            if (sub.isEmpty()) break;
-            CharSequence subbedPassword = translate(password, sub);
-            for (Match match : new DictionaryMatcher(this.getContext(), rankedDictionaries).execute(subbedPassword)) {
-                WipeableString token = WipeableString.copy(password, match.i, match.j + 1);
-                WipeableString lower = WipeableString.lowerCase(token);
-                if (lower.equals(match.matchedWord)) {
-                    token.wipe();
-                    lower.wipe();
-                    continue;
-                }
-                Map<Character, Character> matchSub = new HashMap<>();
-                for (Map.Entry<Character, Character> subRef : sub.entrySet()) {
-                    Character subbedChr = subRef.getKey();
-                    Character chr = subRef.getValue();
-                    if (token.indexOf(subbedChr) != -1) {
-                        matchSub.put(subbedChr, chr);
-                    }
-                }
-                List<String> subDisplays = new ArrayList<>();
-                for (Map.Entry<Character, Character> matchSubRef : matchSub.entrySet()) {
-                    Character k = matchSubRef.getKey();
-                    Character v = matchSubRef.getValue();
-                    subDisplays.add(String.format("%s -> %s", k, v));
-                }
-                String subDisplay = Arrays.toString(subDisplays.toArray(new String[]{}));
-                matches.add(MatchFactory.createDictionaryL33tMatch(
-                        match.i,
-                        match.j,
-                        token,
-                        match.matchedWord,
-                        match.rank,
-                        match.dictionaryName,
-                        match.reversed,
-                        matchSub,
-                        subDisplay));
-                // Don't wipe token as the Match needs it
-                lower.wipe();
-            }
+  @Override
+  public List<Match> execute(CharSequence password) {
+    List<Match> matches = new ArrayList<>();
+    Map<Character, List<Character>> subTable = relevantL33tSubTable(password);
+    L33tSubDict l33tSubs = new L33tSubDict(subTable);
+    for (Map<Character, Character> sub : l33tSubs) {
+      if (sub.isEmpty()) break;
+      CharSequence subbedPassword = translate(password, sub);
+      for (Match match :
+          new DictionaryMatcher(this.getContext(), rankedDictionaries).execute(subbedPassword)) {
+        WipeableString token = WipeableString.copy(password, match.i, match.j + 1);
+        WipeableString lower = WipeableString.lowerCase(token);
+        if (lower.equals(match.matchedWord)) {
+          token.wipe();
+          lower.wipe();
+          continue;
         }
-        List<Match> lst = new ArrayList<>();
-        for (Match match : matches) if (match.tokenLength() > 1) lst.add(match);
-        return this.sorted(lst);
+        Map<Character, Character> matchSub = new HashMap<>();
+        for (Map.Entry<Character, Character> subRef : sub.entrySet()) {
+          Character subbedChr = subRef.getKey();
+          Character chr = subRef.getValue();
+          if (token.indexOf(subbedChr) != -1) {
+            matchSub.put(subbedChr, chr);
+          }
+        }
+        List<String> subDisplays = new ArrayList<>();
+        for (Map.Entry<Character, Character> matchSubRef : matchSub.entrySet()) {
+          Character k = matchSubRef.getKey();
+          Character v = matchSubRef.getValue();
+          subDisplays.add(String.format("%s -> %s", k, v));
+        }
+        String subDisplay = Arrays.toString(subDisplays.toArray(new String[] {}));
+        matches.add(
+            MatchFactory.createDictionaryL33tMatch(
+                match.i,
+                match.j,
+                token,
+                match.matchedWord,
+                match.rank,
+                match.dictionaryName,
+                match.reversed,
+                matchSub,
+                subDisplay));
+        // Don't wipe token as the Match needs it
+        lower.wipe();
+      }
     }
-
+    List<Match> lst = new ArrayList<>();
+    for (Match match : matches) if (match.tokenLength() > 1) lst.add(match);
+    return this.sorted(lst);
+  }
 }

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
@@ -2,38 +2,33 @@ package com.nulabinc.zxcvbn.matchers;
 
 import com.nulabinc.zxcvbn.Context;
 import com.nulabinc.zxcvbn.WipeableString;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class L33tMatcher extends BaseMatcher {
 
   private final Map<String, Map<String, Integer>> rankedDictionaries;
+  private static final Map<Character, List<Character>> L33T_TABLE =
+      Collections.unmodifiableMap(
+          new HashMap<Character, List<Character>>() {
+            {
+              put('a', Arrays.asList('4', '@'));
+              put('b', Collections.singletonList('8'));
+              put('c', Arrays.asList('(', '{', '[', '<'));
+              put('e', Collections.singletonList('3'));
+              put('g', Arrays.asList('6', '9'));
+              put('i', Arrays.asList('1', '!', '|'));
+              put('l', Arrays.asList('1', '|', '7'));
+              put('o', Collections.singletonList('0'));
+              put('s', Arrays.asList('$', '5'));
+              put('t', Arrays.asList('+', '7'));
+              put('x', Collections.singletonList('%'));
+              put('z', Collections.singletonList('2'));
+            }
+          });
 
   public L33tMatcher(Context context, Map<String, Map<String, Integer>> rankedDictionaries) {
     super(context);
     this.rankedDictionaries = rankedDictionaries;
-  }
-
-  private static final Map<Character, List<Character>> L33T_TABLE;
-
-  static {
-    Map<Character, List<Character>> l33tTable = new HashMap<>();
-    l33tTable.put('a', Arrays.asList('4', '@'));
-    l33tTable.put('b', Arrays.asList('8'));
-    l33tTable.put('c', Arrays.asList('(', '{', '[', '<'));
-    l33tTable.put('e', Arrays.asList('3'));
-    l33tTable.put('g', Arrays.asList('6', '9'));
-    l33tTable.put('i', Arrays.asList('1', '!', '|'));
-    l33tTable.put('l', Arrays.asList('1', '|', '7'));
-    l33tTable.put('o', Arrays.asList('0'));
-    l33tTable.put('s', Arrays.asList('$', '5'));
-    l33tTable.put('t', Arrays.asList('+', '7'));
-    l33tTable.put('x', Arrays.asList('%'));
-    l33tTable.put('z', Arrays.asList('2'));
-    L33T_TABLE = l33tTable;
   }
 
   public Map<Character, List<Character>> relevantL33tSubTable(CharSequence password) {
@@ -42,9 +37,9 @@ public class L33tMatcher extends BaseMatcher {
 
   public Map<Character, List<Character>> relevantL33tSubTable(
       CharSequence password, Map<Character, List<Character>> table) {
-    HashMap<Character, Boolean> passwordChars = new HashMap<>();
+    HashSet<Character> passwordChars = new HashSet<>();
     for (int n = 0; n < password.length(); n++) {
-      passwordChars.put(password.charAt(n), true);
+      passwordChars.add(password.charAt(n));
     }
     Map<Character, List<Character>> subTable = new HashMap<>();
     for (Map.Entry<Character, List<Character>> l33tRowRef : table.entrySet()) {
@@ -52,11 +47,11 @@ public class L33tMatcher extends BaseMatcher {
       List<Character> subs = l33tRowRef.getValue();
       List<Character> relevantSubs = new ArrayList<>();
       for (Character sub : subs) {
-        if (passwordChars.containsKey(sub)) {
+        if (passwordChars.contains(sub)) {
           relevantSubs.add(sub);
         }
       }
-      if (relevantSubs.size() > 0) {
+      if (!relevantSubs.isEmpty()) {
         subTable.put(letter, relevantSubs);
       }
     }
@@ -68,11 +63,17 @@ public class L33tMatcher extends BaseMatcher {
     List<Match> matches = new ArrayList<>();
     Map<Character, List<Character>> subTable = relevantL33tSubTable(password);
     L33tSubDict l33tSubs = new L33tSubDict(subTable);
+    DictionaryMatcher dictionaryMatcher =
+        new DictionaryMatcher(this.getContext(), rankedDictionaries);
+
     for (Map<Character, Character> sub : l33tSubs) {
-      if (sub.isEmpty()) break;
-      CharSequence subbedPassword = translate(password, sub);
-      for (Match match :
-          new DictionaryMatcher(this.getContext(), rankedDictionaries).execute(subbedPassword)) {
+      if (sub.isEmpty()) {
+        break; // corner case: password has no relevant subs.
+      }
+      CharSequence subbedPassword = decodeL33tSpeak(password, sub);
+
+      for (Match match : dictionaryMatcher.execute(subbedPassword)) {
+
         WipeableString token = WipeableString.copy(password, match.i, match.j + 1);
         WipeableString lower = WipeableString.lowerCase(token);
         if (lower.equals(match.matchedWord)) {
@@ -80,21 +81,10 @@ public class L33tMatcher extends BaseMatcher {
           lower.wipe();
           continue;
         }
-        Map<Character, Character> matchSub = new HashMap<>();
-        for (Map.Entry<Character, Character> subRef : sub.entrySet()) {
-          Character subbedChr = subRef.getKey();
-          Character chr = subRef.getValue();
-          if (token.indexOf(subbedChr) != -1) {
-            matchSub.put(subbedChr, chr);
-          }
-        }
-        List<String> subDisplays = new ArrayList<>();
-        for (Map.Entry<Character, Character> matchSubRef : matchSub.entrySet()) {
-          Character k = matchSubRef.getKey();
-          Character v = matchSubRef.getValue();
-          subDisplays.add(String.format("%s -> %s", k, v));
-        }
-        String subDisplay = Arrays.toString(subDisplays.toArray(new String[] {}));
+
+        Map<Character, Character> matchSub = extractMatchSub(token, sub);
+        String subDisplay = generateSubDisplay(matchSub);
+
         matches.add(
             MatchFactory.createDictionaryL33tMatch(
                 match.i,
@@ -110,8 +100,52 @@ public class L33tMatcher extends BaseMatcher {
         lower.wipe();
       }
     }
-    List<Match> lst = new ArrayList<>();
-    for (Match match : matches) if (match.tokenLength() > 1) lst.add(match);
-    return this.sorted(lst);
+    return filterMatches(matches);
+  }
+
+  private Map<Character, Character> extractMatchSub(
+      WipeableString token, Map<Character, Character> sub) {
+    Map<Character, Character> matchSub = new HashMap<>();
+    for (Map.Entry<Character, Character> subRef : sub.entrySet()) {
+      Character subbedChr = subRef.getKey();
+      Character chr = subRef.getValue();
+      if (token.indexOf(subbedChr) != -1) {
+        matchSub.put(subbedChr, chr);
+      }
+    }
+    return matchSub;
+  }
+
+  private String generateSubDisplay(Map<Character, Character> matchSub) {
+    List<String> subDisplays = new ArrayList<>();
+    for (Map.Entry<Character, Character> matchSubRef : matchSub.entrySet()) {
+      Character k = matchSubRef.getKey();
+      Character v = matchSubRef.getValue();
+      subDisplays.add(String.format("%s -> %s", k, v));
+    }
+    return Arrays.toString(subDisplays.toArray(new String[0]));
+  }
+
+  private List<Match> filterMatches(List<Match> matches) {
+    List<Match> filteredMatches = new ArrayList<>();
+    for (Match match : matches) {
+      if (match.tokenLength() > 1) {
+        filteredMatches.add(match);
+      }
+    }
+    return this.sorted(filteredMatches);
+  }
+
+  private CharSequence decodeL33tSpeak(
+      CharSequence password, Map<Character, Character> l33tToRegularMapping) {
+    StringBuilder sb = new StringBuilder(password.length());
+    for (int charIndex = 0; charIndex < password.length(); charIndex++) {
+      char curChar = password.charAt(charIndex);
+      Character replacement = l33tToRegularMapping.get(curChar);
+      sb.append(replacement != null ? replacement : curChar);
+    }
+    WipeableString result = new WipeableString(sb);
+    WipeableString.wipeIfPossible(sb);
+    return result;
   }
 }


### PR DESCRIPTION
refactoring matchers. L33tMatcher:
- Extracted part of the process within the `execute` function into a separate function.
- Applied [google-java-format](https://plugins.jetbrains.com/plugin/8527-google-java-format).
- Renamed the `translate` function in `BaseMatcher` to `decodeL33tSpeak` and moved it to `L33tMatcher`.
- Changed type of `L33T_TABLE` to an `UnmodifiableMap`.
- Reduced computational complexity by changing `passwordChars` in the `relevantL33tSubTable` function from `HashMap<Character, Boolean>` to `HashSet<Character>`.