### PR TITLE
refactor: refactoring matchers.RegexMatcher

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/matchers/RegexMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/RegexMatcher.java
@@ -2,7 +2,6 @@ package com.nulabinc.zxcvbn.matchers;
 
 import com.nulabinc.zxcvbn.Context;
 import com.nulabinc.zxcvbn.WipeableString;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -11,31 +10,29 @@ import java.util.regex.*;
 
 public class RegexMatcher extends BaseMatcher {
 
-    private static final Map<String, String> REGEXEN = new HashMap<>();
-    static {
-        REGEXEN.put("recent_year", "19\\d\\d|200\\d|201\\d|202\\d");
-    }
+  private static final Map<String, String> REGEXEN = new HashMap<>();
 
-    public RegexMatcher(final Context context) {
-        super(context);
-    }
+  static {
+    REGEXEN.put("recent_year", "19\\d\\d|200\\d|201\\d|202\\d");
+  }
 
-    @Override
-    public List<Match> execute(CharSequence password) {
-        List<Match> matches = new ArrayList<>();
-        for(Map.Entry<String, String> regexenRef: REGEXEN.entrySet()) {
-            String name = regexenRef.getKey();
-            java.util.regex.Matcher rxMatch = Pattern.compile(regexenRef.getValue()).matcher(password);
-            while(rxMatch.find()){
-                CharSequence token = new WipeableString(rxMatch.group());
-                matches.add(MatchFactory.createRegexMatch(
-                        rxMatch.start(),
-                        rxMatch.start() + token.length() - 1,
-                        token,
-                        name,
-                        rxMatch));
-            }
-        }
-        return this.sorted(matches);
+  public RegexMatcher(final Context context) {
+    super(context);
+  }
+
+  @Override
+  public List<Match> execute(CharSequence password) {
+    List<Match> matches = new ArrayList<>();
+    for (Map.Entry<String, String> regexenRef : REGEXEN.entrySet()) {
+      String name = regexenRef.getKey();
+      java.util.regex.Matcher rxMatch = Pattern.compile(regexenRef.getValue()).matcher(password);
+      while (rxMatch.find()) {
+        CharSequence token = new WipeableString(rxMatch.group());
+        matches.add(
+            MatchFactory.createRegexMatch(
+                rxMatch.start(), rxMatch.start() + token.length() - 1, token, name, rxMatch));
+      }
     }
+    return this.sorted(matches);
+  }
 }

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/RegexMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/RegexMatcher.java
@@ -10,10 +10,10 @@ import java.util.regex.*;
 
 public class RegexMatcher extends BaseMatcher {
 
-  private static final Map<String, String> REGEXEN = new HashMap<>();
+  private static final Map<String, Pattern> PATTERNS = new HashMap<>();
 
   static {
-    REGEXEN.put("recent_year", "19\\d\\d|200\\d|201\\d|202\\d");
+    PATTERNS.put("recent_year", Pattern.compile("19\\d\\d|200\\d|201\\d|202\\d"));
   }
 
   public RegexMatcher(final Context context) {
@@ -23,14 +23,14 @@ public class RegexMatcher extends BaseMatcher {
   @Override
   public List<Match> execute(CharSequence password) {
     List<Match> matches = new ArrayList<>();
-    for (Map.Entry<String, String> regexenRef : REGEXEN.entrySet()) {
-      String name = regexenRef.getKey();
-      java.util.regex.Matcher rxMatch = Pattern.compile(regexenRef.getValue()).matcher(password);
-      while (rxMatch.find()) {
-        CharSequence token = new WipeableString(rxMatch.group());
+    for (Map.Entry<String, Pattern> patternRef : PATTERNS.entrySet()) {
+      String name = patternRef.getKey();
+      java.util.regex.Matcher matcher = patternRef.getValue().matcher(password);
+      while (matcher.find()) {
+        CharSequence token = new WipeableString(matcher.group());
         matches.add(
             MatchFactory.createRegexMatch(
-                rxMatch.start(), rxMatch.start() + token.length() - 1, token, name, rxMatch));
+                matcher.start(), matcher.start() + token.length() - 1, token, name, matcher));
       }
     }
     return this.sorted(matches);


### PR DESCRIPTION
refactoring matchers. L33tMatcher:
- Applied [google-java-format](https://plugins.jetbrains.com/plugin/8527-google-java-format).
- REGEXEN was changed to PATTERNS, and it now holds Pattern objects. This ensures that the pattern is compiled only once, improving performance.
The unnecessary Pattern.compile call inside the loop was removed.