### PR TITLE
fix: improved SpatialMatcher decision logic (#84) (#129)

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/guesses/SpatialGuess.java
+++ b/src/main/java/com/nulabinc/zxcvbn/guesses/SpatialGuess.java
@@ -27,7 +27,7 @@ public class SpatialGuess extends BaseGuess {
         if (match.shiftedCount > 0) {
             int shiftedCount = match.shiftedCount;
             int unshiftedCount = match.tokenLength() - match.shiftedCount;
-            if (unshiftedCount == 0) {
+            if (shiftedCount == 0 || unshiftedCount == 0) {
                 guesses *= 2;
             } else {
                 int shiftedVariations = 0;

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/SpatialMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/SpatialMatcher.java
@@ -48,7 +48,7 @@ public class SpatialMatcher extends BaseMatcher {
   private int processSpatialMatch(
       CharSequence password, Keyboard keyboard, List<Match> matches, int curCharIndex) {
     int nextCharIndex = curCharIndex + 1;
-    int lastDirection = 0;
+    Integer lastDirection = null;
     int turns = 0;
     int shiftedCount = calculateShiftedCount(keyboard, password.charAt(curCharIndex));
     final Map<Character, List<String>> graph = keyboard.getAdjacencyGraph();
@@ -59,7 +59,9 @@ public class SpatialMatcher extends BaseMatcher {
       if (result.found) {
         nextCharIndex++;
         shiftedCount += result.shiftedCount;
-        if (lastDirection != result.foundDirection) {
+        if (lastDirection == null || lastDirection != result.foundDirection) {
+          // adding a turn is correct even in the initial case when last_direction is null:
+          // every spatial pattern starts with a turn.
           turns++;
           lastDirection = result.foundDirection;
         }

--- a/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/FeedbackTest.java
@@ -134,9 +134,9 @@ public class FeedbackTest {
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
                         Feedback.SPATIAL_SUGGESTIONS_USE_LONGER_KEYBOARD_PATTERN
                 }},
-                {"lkjhgfdsa", Feedback.SPATIAL_WARNING_SHORT_KEYBOARD_PATTERNS, new String[]{
+                {"lkjhgfdsa", Feedback.DICTIONARY_WARNING_PASSWORDS_SIMILAR, new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD,
-                        Feedback.SPATIAL_SUGGESTIONS_USE_LONGER_KEYBOARD_PATTERN
+                        Feedback.DICTIONARY_SUGGESTIONS_REVERSED
                 }},
                 {"justshort", "", new String[]{
                         Feedback.EXTRA_SUGGESTIONS_ADD_ANOTHER_WORD

--- a/src/test/java/com/nulabinc/zxcvbn/JavaPortTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/JavaPortTest.java
@@ -40,7 +40,8 @@ public class JavaPortTest {
         } else {
             jsScore = (int) score;
         }
-        int javaScore = zxcvbn.measure(password).getScore();
+        Strength strength = zxcvbn.measure(password);
+        int javaScore = strength.getScore();
         Assert.assertEquals("Password score difference for " + password, jsScore, javaScore);
     }
 
@@ -85,6 +86,10 @@ public class JavaPortTest {
                 {"61526611441"},
                 {"0078690420729"},
                 {"zhang198822"},
+                {"Sigma@123"},
+                {"password@123"},
+                {"lkjhgfdsa"},
+                {"hGFd"},
                 //the following password fails in version 4.4.1
                 //https://github.com/dropbox/zxcvbn/issues/174
 //                {"Rh&pW%EXT=/Z1lzouG.wU_+2MT+FG4sm+&jqN?L25jDtjW3EQuppfvD_30Vo3K=SX4=z3-U2gVf7A0oSM5oWegRa_sV$-GLI3LzCo&@!h@$v#OkoN#@-eS8Y&W$pGmmVXc#XHAv?n$M+_wQx1FAB_*iaZE1_9ZV.cwn-d@+90B8z0bVOKc63lV9QntW0kryN7Y#rjv@0+Bd8hc-3WW_Yn%z5/DE?R*UeiKgR#$/F8kA9I!Ib*GDa.x0T7UWCCxDV&ithebyz$=7vW6TdmlmL%WZxmA7K%*Rg1035UO%WOTIgiMs4AjpmL1"}

--- a/src/test/java/com/nulabinc/zxcvbn/MatchingTest.java
+++ b/src/test/java/com/nulabinc/zxcvbn/MatchingTest.java
@@ -243,7 +243,7 @@ public class MatchingTest {
                     {"12345", qwerty, 1, 0},
                     {"@WSX", qwerty, 1, 4},
                     {"6tfGHJ", qwerty, 2, 3},
-                    {"hGFd", qwerty, 0, 2},
+                    {"hGFd", qwerty, 1, 2},
                     {"/;p09876yhn", qwerty, 3, 0},
                     {"Xdr%", qwerty, 1, 2},
                     {"159-", keypad, 1, 0},


### PR DESCRIPTION
**Describe the change**

Improved SpatialMatcher decision logic.

**Describe your solution**

- The decision logic of SpatialMatcher's lastDirection has been made consistent with the origin.
- Match the increment logic of the guess value in SpatialGuess with the origin.

**Tests**

Added "Sigma@123" and "password@123" to JavaPortTest parameters.

**Additional context**

Issue:  #84 #129