### PR TITLE
fix: Fix sonarcloud reliability

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/Scoring.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Scoring.java
@@ -119,7 +119,7 @@ public class Scoring {
     metrics = handleInfinity(metrics);
 
     if (!excludeAdditive) {
-      metrics += Math.pow(MIN_GUESSES_BEFORE_GROWING_SEQUENCE, l - 1);
+      metrics += Math.pow(MIN_GUESSES_BEFORE_GROWING_SEQUENCE, (double) l - 1);
       metrics = handleInfinity(metrics);
     }
 

--- a/src/main/java/com/nulabinc/zxcvbn/TimeEstimates.java
+++ b/src/main/java/com/nulabinc/zxcvbn/TimeEstimates.java
@@ -79,8 +79,8 @@ public class TimeEstimates {
   }
 
   private static double divide(double dividend, double divisor) {
-    BigDecimal dividendDecimal = new BigDecimal(dividend);
-    BigDecimal divisorDecimal = new BigDecimal(divisor);
+    BigDecimal dividendDecimal = BigDecimal.valueOf(dividend);
+    BigDecimal divisorDecimal = BigDecimal.valueOf(divisor);
     return dividendDecimal.divide(divisorDecimal, RoundingMode.HALF_DOWN).doubleValue();
   }
 }

--- a/src/main/java/com/nulabinc/zxcvbn/guesses/DictionaryGuess.java
+++ b/src/main/java/com/nulabinc/zxcvbn/guesses/DictionaryGuess.java
@@ -23,7 +23,7 @@ public class DictionaryGuess extends BaseGuess {
     int uppercaseVariations = uppercaseVariations(match);
     int l33tVariations = l33tVariations(match);
     int reversedVariations = match.reversed ? 2 : 1;
-    return match.rank * uppercaseVariations * l33tVariations * reversedVariations;
+    return (double) match.rank * uppercaseVariations * l33tVariations * reversedVariations;
   }
 
   public int uppercaseVariations(Match match) {

--- a/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
+++ b/src/main/java/com/nulabinc/zxcvbn/matchers/L33tMatcher.java
@@ -13,24 +13,24 @@ import java.util.Map;
 public class L33tMatcher extends BaseMatcher {
 
   private final Map<String, Map<String, Integer>> rankedDictionaries;
-  private static final Map<Character, List<Character>> L33T_TABLE =
-      Collections.unmodifiableMap(
-          new HashMap<Character, List<Character>>() {
-            {
-              put('a', Arrays.asList('4', '@'));
-              put('b', Collections.singletonList('8'));
-              put('c', Arrays.asList('(', '{', '[', '<'));
-              put('e', Collections.singletonList('3'));
-              put('g', Arrays.asList('6', '9'));
-              put('i', Arrays.asList('1', '!', '|'));
-              put('l', Arrays.asList('1', '|', '7'));
-              put('o', Collections.singletonList('0'));
-              put('s', Arrays.asList('$', '5'));
-              put('t', Arrays.asList('+', '7'));
-              put('x', Collections.singletonList('%'));
-              put('z', Collections.singletonList('2'));
-            }
-          });
+  private static final Map<Character, List<Character>> L33T_TABLE;
+
+  static {
+    Map<Character, List<Character>> table = new HashMap<>();
+    table.put('a', Arrays.asList('4', '@'));
+    table.put('b', Collections.singletonList('8'));
+    table.put('c', Arrays.asList('(', '{', '[', '<'));
+    table.put('e', Collections.singletonList('3'));
+    table.put('g', Arrays.asList('6', '9'));
+    table.put('i', Arrays.asList('1', '!', '|'));
+    table.put('l', Arrays.asList('1', '|', '7'));
+    table.put('o', Collections.singletonList('0'));
+    table.put('s', Arrays.asList('$', '5'));
+    table.put('t', Arrays.asList('+', '7'));
+    table.put('x', Collections.singletonList('%'));
+    table.put('z', Collections.singletonList('2'));
+    L33T_TABLE = Collections.unmodifiableMap(table);
+  }
 
   public L33tMatcher(Context context, Map<String, Map<String, Integer>> rankedDictionaries) {
     super(context);


### PR DESCRIPTION
Fix sonarcloud reliability:
- Use another way to initialize this instance in L33tMatcher.
- Cast one of the operands of this subtraction operation to a double in Scoring.
- Use BigDecimal.valueOf instead in TimeEstimates.
- Cast one of the operands of this multiplication operation to a double in DictionaryGuess.
