### PR TITLE
refactor: modifier 'private' is redundant for enum constructors

### DIFF
--- a/src/main/java/com/nulabinc/zxcvbn/Pattern.java
+++ b/src/main/java/com/nulabinc/zxcvbn/Pattern.java
@@ -12,7 +12,7 @@ public enum Pattern {
 
   private final String value;
 
-  private Pattern(final String value) {
+  Pattern(final String value) {
     this.value = value;
   }
 


### PR DESCRIPTION
Modifier 'private' is redundant for enum constructors.